### PR TITLE
fix: short name of subject if title is too long

### DIFF
--- a/lib/presentation/pages/grades_page/avg_grade_tile.dart
+++ b/lib/presentation/pages/grades_page/avg_grade_tile.dart
@@ -40,7 +40,7 @@ class AvgGradeTile extends StatelessWidget {
             );
           },
           leading: Icon(Icons.leaderboard_outlined),
-          title: Text(subject.name),
+          title: Text(subject.name.length > 17 ? subject.shortName : subject.name),
           trailing:
               avgGrade == -1
                   ? Icon(Icons.block)

--- a/lib/presentation/pages/timetable_page/timetable_list/lesson_tile_timetable.dart
+++ b/lib/presentation/pages/timetable_page/timetable_list/lesson_tile_timetable.dart
@@ -32,7 +32,7 @@ class TimetableLessonTile extends StatelessWidget {
             showLessonTileBottomSheet(context, lesson);
           },
           title: Text(
-            subject.name,
+            subject.name.length > 17 ? subject.shortName : subject.name,
             style:
                 Theme.of(context).textTheme.titleMedium?.copyWith(
                   fontWeight: FontWeight.bold,


### PR DESCRIPTION
Yeah that's literally it. In avg tile and lesson tile there is now the short name of the subject used when the name of the subject exceeds 17 characters.